### PR TITLE
Fix missing import in compare.py

### DIFF
--- a/06-circl/remote/setup/compare.py
+++ b/06-circl/remote/setup/compare.py
@@ -6,6 +6,7 @@ import seaborn as sns
 import numpy as np
 import re
 import sys
+import os
 
 
 try:


### PR DESCRIPTION
Missing 'os' import in [06-circl/remote/setup/compare.py](https://github.com/FPSG-UIUC/hertzbleed/blob/main/06-circl/remote/setup/compare.py) prevented 'plot' directory form being created, resulting in an error when plt.savefig() ran.